### PR TITLE
Adding Event resources to Other resources

### DIFF
--- a/src/Endpoints/Endpoint.php
+++ b/src/Endpoints/Endpoint.php
@@ -8,6 +8,7 @@ use DeliciousBrains\SpinupWp\Exceptions\TimeoutException;
 use DeliciousBrains\SpinupWp\Exceptions\UnauthorizedException;
 use DeliciousBrains\SpinupWp\Exceptions\ValidationException;
 use DeliciousBrains\SpinupWp\Resources\ResourceCollection;
+use DeliciousBrains\SpinupWp\SpinupWp;
 use Exception;
 use GuzzleHttp\Client;
 use Psr\Http\Message\ResponseInterface;
@@ -15,10 +16,12 @@ use Psr\Http\Message\ResponseInterface;
 abstract class Endpoint
 {
     protected Client $client;
+    public SpinupWp $spinupwp;
 
-    public function __construct(Client $client)
+    public function __construct(Client $client, SpinupWp $spinupwp)
     {
         $this->client = $client;
+        $this->spinupwp = $spinupwp;
     }
 
     protected function request(string $verb, string $uri, array $payload = [])
@@ -78,7 +81,7 @@ abstract class Endpoint
 
     protected function transformCollection(array $payload, string $class, int $page): ResourceCollection
     {
-        return new ResourceCollection($payload, $class, $this, $page);
+        return new ResourceCollection($payload, $class, $this, $this->spinupwp, $page);
     }
 
     protected function wait(callable $callback, int $timeout = 300, int $sleep = 10)

--- a/src/Endpoints/Event.php
+++ b/src/Endpoints/Event.php
@@ -10,6 +10,6 @@ class Event extends Endpoint
     {
         $event = $this->getRequest("events/{$id}");
 
-        return new EventResource($event['data'], $this);
+        return new EventResource($event['data'], $this, $this->spinupwp);
     }
 }

--- a/src/Endpoints/Server.php
+++ b/src/Endpoints/Server.php
@@ -18,6 +18,6 @@ class Server extends Endpoint
     {
         $server = $this->getRequest("servers/{$id}");
 
-        return new ServerResource($server['data'], $this);
+        return new ServerResource($server['data'], $this, $this->spinupwp);
     }
 }

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -3,6 +3,7 @@
 namespace DeliciousBrains\SpinupWp\Resources;
 
 use DeliciousBrains\SpinupWp\Endpoints\Endpoint;
+use DeliciousBrains\SpinupWp\SpinupWp;
 
 abstract class Resource
 {
@@ -10,10 +11,13 @@ abstract class Resource
 
     protected Endpoint $endpoint;
 
-    public function __construct(array $attributes, Endpoint $endpoint)
+    public SpinupWp $spinupwp;
+
+    public function __construct(array $attributes, Endpoint $endpoint, SpinupWp $spinupwp)
     {
         $this->attributes = $attributes;
         $this->endpoint   = $endpoint;
+        $this->spinupwp   = $spinupwp;
 
         $this->fill();
     }
@@ -22,6 +26,9 @@ abstract class Resource
     {
         foreach ($this->attributes as $key => $value) {
             $this->{$key} = $value;
+        }
+        if(property_exists($this,'event_id') && $this->event_id) {
+            $this->event = $this->spinupwp->events->get($this->event_id);
         }
     }
 }

--- a/src/Resources/ResourceCollection.php
+++ b/src/Resources/ResourceCollection.php
@@ -4,6 +4,7 @@ namespace DeliciousBrains\SpinupWp\Resources;
 
 use Countable;
 use DeliciousBrains\SpinupWp\Endpoints\Endpoint;
+use DeliciousBrains\SpinupWp\SpinupWp;
 use Generator;
 use IteratorAggregate;
 
@@ -15,15 +16,18 @@ class ResourceCollection implements Countable, IteratorAggregate
 
     protected Endpoint $endpoint;
 
+    public SpinupWp $spinupwp;
+
     protected int $page;
 
     protected array $data;
 
-    public function __construct(array $payload, string $class, Endpoint $endpoint, int $page = 1)
+    public function __construct(array $payload, string $class, Endpoint $endpoint, SpinupWp $spinupwp, int $page = 1)
     {
         $this->payload  = $payload;
         $this->class    = $class;
         $this->endpoint = $endpoint;
+        $this->spinupwp = $spinupwp;
         $this->page     = $page;
 
         $this->mapResourceClass();
@@ -32,7 +36,7 @@ class ResourceCollection implements Countable, IteratorAggregate
     protected function mapResourceClass(): void
     {
         $this->data = array_map(function ($data) {
-            return new $this->class($data, $this->endpoint);
+            return new $this->class($data, $this->endpoint, $this->spinupwp);
         }, $this->payload['data']);
     }
 

--- a/src/Resources/Site.php
+++ b/src/Resources/Site.php
@@ -2,9 +2,14 @@
 
 namespace DeliciousBrains\SpinupWp\Resources;
 
+use DeliciousBrains\SpinupWp\Traits\HasEvent;
+use DeliciousBrains\SpinupWp\Resources\Event as EventResource;
+
 class Site extends Resource
 {
-    public function delete(): int
+    use HasEvent;
+
+    public function delete(): EventResource
     {
         return $this->endpoint->delete($this->id);
     }

--- a/src/SpinupWp.php
+++ b/src/SpinupWp.php
@@ -48,7 +48,7 @@ class SpinupWp
         $class = $this->buildEndpointClass($name);
 
         if (class_exists($class)) {
-            $this->endpoints[$name] = new $class($this->client);
+            $this->endpoints[$name] = new $class($this->client, $this);
 
             return $this->endpoints[$name];
         }

--- a/src/Traits/HasEvent.php
+++ b/src/Traits/HasEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace DeliciousBrains\SpinupWp\Traits;
+
+trait HasEvent {
+    public int $event_id = 0;
+
+    public function event()
+    {
+        if(!$this->event_id){
+            return null;
+        }
+
+        return $this->spinupwp->events->get($this->event_id);
+    }
+}


### PR DESCRIPTION
This PR includes a slight refactor which sends the `SpinupWP` instance down the chain so calls can be made to other endpoints. I had to leave the `Endpoint` in the chain as well because of Resource Collections and pagination. I'm not at all sure I've done this in the simplest way, but it does work.

I've added a `Trait` instead of a helper since that made since to my brain, although it's not always true, so maybe it's not the best choice. 
 