### PR TITLE
filter and load sites by server

### DIFF
--- a/src/Endpoints/Site.php
+++ b/src/Endpoints/Site.php
@@ -15,6 +15,13 @@ class Site extends Endpoint
         return $this->transformCollection($sites, SiteResource::class, $page);
     }
 
+    public function listForServer(int $serverId, int $page = 1): ResourceCollection
+    {
+        $sites = $this->getRequest("sites?server_id={$serverId}&page={$page}");
+
+        return $this->transformCollection($sites, SiteResource::class, $page);
+    }
+
     public function get(int $id): SiteResource
     {
         $site = $this->getRequest("sites/{$id}");

--- a/src/Resources/Server.php
+++ b/src/Resources/Server.php
@@ -4,5 +4,8 @@ namespace DeliciousBrains\SpinupWp\Resources;
 
 class Server extends Resource
 {
-
+    public function sites(): ResourceCollection
+    {
+        return $this->spinupwp->sites->listForServer($this->id);
+    }
 }


### PR DESCRIPTION
Resolves #2 

Building on top of @katelynnbarlowe's work in https://github.com/deliciousbrains/spinupwp-php-sdk/pull/5, this PR:

- adds a second public method to `Sites` endpoint for server specific listing
- adds a `->sites()` method to the `Server` resource type