### PR TITLE
default Resource::toArray()

### DIFF
--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -18,6 +18,11 @@ abstract class Resource
         $this->fill();
     }
 
+    public function toArray(): array
+    {
+        return $this->attributes;
+    }
+
     protected function fill()
     {
         foreach ($this->attributes as $key => $value) {


### PR DESCRIPTION
Resolves #4 

Adds a default `toArray()` method on the base `Resource` class. 

I don't believe we currently have any Resources which would require additional transformation beyond this.